### PR TITLE
Example of pybind11 problems

### DIFF
--- a/foo/setup.py
+++ b/foo/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 
+ext_modules = [Pybind11Extension("foo", [])]
 setup(
     name="foo",
     version="0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "monodemo"
 dependencies = [
     "flask",
+    "pybind11>=2.13.1",
     "foo @ file:///${PROJECT_ROOT}/foo",
 ]
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -16,8 +16,6 @@ click==8.1.7
 exceptiongroup==1.2.2
     # via pytest
 flask==2.3.3
-    # via foo
-foo @ file:///${PROJECT_ROOT}/foo
 iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
@@ -31,6 +29,7 @@ packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
+pybind11==2.13.1
 pytest==8.3.1
 tomli==2.0.1
     # via pytest

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,8 +14,6 @@ blinker==1.8.2
 click==8.1.7
     # via flask
 flask==2.3.3
-    # via foo
-foo @ file:///${PROJECT_ROOT}/foo
 itsdangerous==2.2.0
     # via flask
 jinja2==3.1.4
@@ -23,5 +21,6 @@ jinja2==3.1.4
 markupsafe==2.1.5
     # via jinja2
     # via werkzeug
+pybind11==2.13.1
 werkzeug==3.0.3
     # via flask


### PR DESCRIPTION
If the local utility lib requires build dependencies, I'm not sure how to specify that in the project. In this PR I can install `./foo` with a Python interpreter if that has `pybind11` included already, e.g.

```
pip install pybind11
pip install ./foo
```

However I can't get `rye sync` to build `./foo` even if it's synced with `pybind11` first. Likewise `uv pip install pybind11` -> `uv pip install ./foo` throws "pybind11 not found".